### PR TITLE
Captured groups in RegEx routes are assigned to the params

### DIFF
--- a/packages/ember-routemanager/lib/route_manager.js
+++ b/packages/ember-routemanager/lib/route_manager.js
@@ -435,7 +435,7 @@ Ember.RouteManager = Ember.StateManager.extend({
         }
         var part = parts.shift();
         var partDefinition = partDefinitions[i];
-        var partParams = this._matchPart(partDefinition, part);
+        var partParams = this._matchPart(partDefinition, part, state);
         if(!partParams) {
           return false;
         }
@@ -465,7 +465,9 @@ Ember.RouteManager = Ember.StateManager.extend({
   /** @private
    Returns params if the part matches the partDefinition
    */
-  _matchPart: function(partDefinition, part) {
+  _matchPart: function(partDefinition, part, state) {
+    var params = {};
+
     // Handle string parts
     if( typeof partDefinition == "string") {
 
@@ -473,7 +475,6 @@ Ember.RouteManager = Ember.StateManager.extend({
         // 1. dynamic routes
         case ':':
           var name = partDefinition.slice(1, partDefinition.length);
-          var params = {};
           params[name] = part;
           return params;
 
@@ -491,8 +492,26 @@ Ember.RouteManager = Ember.StateManager.extend({
       return false;
     }
 
-    // Handle RegExp parts
-    return partDefinition.test(part) ? {} : false;
+    if (partDefinition instanceof RegExp) {
+      // JS doesn't support named capture groups in Regexes so instead
+      // we can define a list of 'captures' which maps to the matched groups
+      var captures = get(state, 'captures');
+      var matches = partDefinition.exec(part);
+
+      if (matches) {
+        if (captures) {
+          var len = captures.length, i;
+          for(i = 0; i < len; ++i) {
+            params[captures[i]] = matches[i+1];
+          }
+        }
+        return params;
+      } else {
+        return false;
+      }
+    }
+
+    return false;
   },
 
   /**

--- a/packages/ember-routemanager/tests/route_manager_test.js
+++ b/packages/ember-routemanager/tests/route_manager_test.js
@@ -169,8 +169,37 @@ test("regexp paths", function() {
   });
   
   routeManager.set('location', 'posts/comments');
-  
+
   ok(stateReached, 'The state should have been reached.');
+});
+
+test("regexp paths with named captures", function() {
+  var stateReached = false;
+  var year, month, day;
+
+  routeManager = Ember.RouteManager.create({
+    posts: Ember.State.create({
+      route: 'posts',
+      archive: Ember.State.create({
+        route: /(\d{4})-(\d{2})-(\d{2})/,
+        captures: ['year', 'month', 'day'],
+        enter: function(stateManager) {
+          stateReached = true;
+          year = stateManager.params.year;
+          month = stateManager.params.month;
+          day = stateManager.params.day;
+        }
+      })
+    })
+  });
+
+  routeManager.set('location', 'posts/2012-08-21');
+
+  ok(stateReached, 'The state should have been reached.');
+
+  equals(year, '2012', "The first match param (year) should have been set.");
+  equals(month, '08', "The second match param (month) should have been set.");
+  equals(day, '21', "The first match param (day) should have been set.");
 });
 
 test("state priorities are obeyed", function() {


### PR DESCRIPTION
Javascript doesn't support named capture groups, so instead I've added a 'captures' property which lets you map the matched group to a name for the params.

Eg (from the tests):

```
Ember.RouteManager.create({
  posts: Ember.State.create({
    route: 'posts',
    archive: Ember.State.create({
      route: /(\d{4})-(\d{2})-(\d{2})/,
      captures: ['year', 'month', 'day']
    })
  })
});
```

If given `/posts/2012-08-21` then it will put the matched `year`, `month` and `day` into the params.
